### PR TITLE
Authentication interface

### DIFF
--- a/src/chunkymonkey/game.go
+++ b/src/chunkymonkey/game.go
@@ -84,11 +84,10 @@ func (game *Game) login(conn net.Conn) {
 		return
 	}
 
-	// TODO put authentication into a seperate module behind an interface so
-	// that authentication is pluggable.
 	if game.serverId != "-" {
 		var authenticated bool
-		authenticated, err = server_auth.CheckUserAuth(game.serverId, username)
+		authserver := &server_auth.ServerAuth{"http://www.minecraft.net/game/checkserver.jsp"}
+		authenticated, err = authserver.Authenticate(game.serverId, username)
 		if !authenticated || err != nil {
 			var reason string
 			if err != nil {


### PR DESCRIPTION
This is just a preliminary authentication interface, removing the TODO item in game.go. The DummyAuth type allows for consistent boolean responses to authentication (although perhaps it needs an err as well), and the ServerAuth is just an abstraction of what already used to happen. If you have something more specific in mind, let me know.
