### PR TITLE
Add support for spawning saplings in generated chunks

### DIFF
--- a/blocks.json
+++ b/blocks.json
@@ -125,8 +125,15 @@
       "Replaceable": false,
       "Attachable": false
     },
-    "Aspect": "Todo",
+    "Aspect": "Sapling",
     "AspectArgs": {
+      "DroppedItems": [
+        {
+          "DroppedItem": 6,
+          "Probability": 100,
+          "Count": 1
+        }
+      ],
       "Comment": "These should grow over time"
     }
   },

--- a/src/chunkymonkey/chunkstore/chunkservice.go
+++ b/src/chunkymonkey/chunkstore/chunkservice.go
@@ -8,7 +8,7 @@ import (
 
 type request struct {
 	chunkLoc     ChunkXz
-	responseChan chan<- ChunkResult
+	responseChan chan<- ChunkReadResult
 }
 
 type IChunkStoreForeground interface {
@@ -33,12 +33,12 @@ func (s *ChunkService) Serve() {
 	for {
 		request := <-s.requests
 		reader, err := s.store.LoadChunk(request.chunkLoc)
-		request.responseChan <- ChunkResult{reader, err}
+		request.responseChan <- ChunkReadResult{reader, err}
 	}
 }
 
-func (s *ChunkService) LoadChunk(chunkLoc ChunkXz) <-chan ChunkResult {
-	responseChan := make(chan ChunkResult)
+func (s *ChunkService) LoadChunk(chunkLoc ChunkXz) <-chan ChunkReadResult {
+	responseChan := make(chan ChunkReadResult)
 
 	s.requests <- request{
 		chunkLoc:     chunkLoc,

--- a/src/chunkymonkey/gamerules/block_loader.go
+++ b/src/chunkymonkey/gamerules/block_loader.go
@@ -191,6 +191,7 @@ func init() {
 	aspectMakers = map[string]aspectMakerFn{
 		"Chest":     makeChestAspect,
 		"Furnace":   makeFurnaceAspect,
+		"Sapling":   makeSaplingAspect,
 		"Standard":  makeStandardAspect,
 		"Todo":      makeTodoAspect,
 		"Void":      makeVoidAspect,

--- a/src/chunkymonkey/gamerules/block_sapling.go
+++ b/src/chunkymonkey/gamerules/block_sapling.go
@@ -10,13 +10,11 @@ import (
 // Behaviour of a sapling block, takes care of growing or dying depending on
 // world conditions.
 func makeSaplingAspect() (aspect IBlockAspect) {
-	return &SaplingAspect{
-		&StandardAspect{},
-	}
+	return &SaplingAspect{}
 }
 
 type SaplingAspect struct {
-	*StandardAspect
+	StandardAspect
 }
 
 func (aspect *SaplingAspect) Name() string {

--- a/src/chunkymonkey/gamerules/block_sapling.go
+++ b/src/chunkymonkey/gamerules/block_sapling.go
@@ -1,7 +1,6 @@
 package gamerules
 
 import (
-	"os"
 	"rand"
 	"time"
 	. "chunkymonkey/types"
@@ -22,10 +21,6 @@ type SaplingAspect struct {
 
 func (aspect *SaplingAspect) Name() string {
 	return "Sapling"
-}
-
-func (aspect *SaplingAspect) Check() os.Error {
-	return nil
 }
 
 var rnd = rand.New(rand.NewSource(time.Nanoseconds()))

--- a/src/chunkymonkey/gamerules/block_sapling.go
+++ b/src/chunkymonkey/gamerules/block_sapling.go
@@ -2,6 +2,9 @@ package gamerules
 
 import (
 	"os"
+	"rand"
+	"time"
+	. "chunkymonkey/types"
 )
 
 // Behaviour of a sapling block, takes care of growing or dying depending on
@@ -24,7 +27,29 @@ func (aspect *SaplingAspect) Check() os.Error {
 	return nil
 }
 
+var rnd = rand.New(rand.NewSource(time.Nanoseconds()))
+
 func (aspect *SaplingAspect) Tick(instance *BlockInstance) bool {
-	// TODO: Need to find a way to bootstrap a tick
+	if rnd.Intn(1e4) >= 1e4-1 {
+		// Turn this block into a tree
+		return aspect.makeTree(instance)
+	}
+	return true
+}
+
+func (aspect *SaplingAspect) makeTree(instance *BlockInstance) bool {
+	loc := instance.SubLoc
+	minheight := 3
+	maxheight := 6
+	height := loc.Y + SubChunkCoord(minheight+rand.Intn(maxheight-minheight))
+
+	for y := loc.Y; y < height; y++ {
+		loc.Y = y
+		index, ok := loc.BlockIndex()
+		if !ok {
+			return false
+		}
+		instance.Chunk.SetBlockByIndex(index, BlockId(17), byte(0))
+	}
 	return true
 }

--- a/src/chunkymonkey/gamerules/block_sapling.go
+++ b/src/chunkymonkey/gamerules/block_sapling.go
@@ -1,0 +1,30 @@
+package gamerules
+
+import (
+	"os"
+)
+
+// Behaviour of a sapling block, takes care of growing or dying depending on
+// world conditions.
+func makeSaplingAspect() (aspect IBlockAspect) {
+	return &SaplingAspect{
+		&StandardAspect{},
+	}
+}
+
+type SaplingAspect struct {
+	*StandardAspect
+}
+
+func (aspect *SaplingAspect) Name() string {
+	return "Sapling"
+}
+
+func (aspect *SaplingAspect) Check() os.Error {
+	return nil
+}
+
+func (aspect *SaplingAspect) Tick(instance *BlockInstance) bool {
+	// TODO: Need to find a way to bootstrap a tick
+	return true
+}

--- a/src/chunkymonkey/gamerules/block_sapling.go
+++ b/src/chunkymonkey/gamerules/block_sapling.go
@@ -5,6 +5,7 @@ import (
 	"rand"
 	"time"
 	. "chunkymonkey/types"
+	"log"
 )
 
 // Behaviour of a sapling block, takes care of growing or dying depending on
@@ -41,15 +42,54 @@ func (aspect *SaplingAspect) makeTree(instance *BlockInstance) bool {
 	loc := instance.SubLoc
 	minheight := 3
 	maxheight := 6
-	height := loc.Y + SubChunkCoord(minheight+rand.Intn(maxheight-minheight))
+	height := minheight + rand.Intn(maxheight-minheight)
+	maxy := loc.Y + SubChunkCoord(height)
 
-	for y := loc.Y; y < height; y++ {
+	for y := loc.Y; y < maxy; y++ {
 		loc.Y = y
 		index, ok := loc.BlockIndex()
 		if !ok {
-			return false
+			// TODO: Can't place a block outside chunk boundaries
+			log.Printf("Couldn't place a tree block (%v,%v,%v)", loc.X, loc.Y, loc.Z)
+		} else {
+			instance.Chunk.SetBlockByIndex(index, BlockId(17), byte(0))
 		}
-		instance.Chunk.SetBlockByIndex(index, BlockId(17), byte(0))
 	}
+
+	// Store the location at the top block of the tree
+	treex, treey, treez := int(loc.X), int(loc.Y), int(loc.Z)
+	cradius := height / 2
+
+	// Start one block above the tree and move down
+	for y := treey + 1; y >= treey-1; y-- {
+		var radius int
+
+		// Slightly round out the canopy
+		if y > treey {
+			radius = cradius - 1
+		} else if y == treey {
+			radius = cradius
+		} else if y < treey {
+			radius = cradius - 1
+		}
+
+		for x := treex - radius; x <= treex+radius; x++ {
+			for z := treez - radius; z <= treez+radius; z++ {
+				if y > treey || x != treex || z != treez {
+					loc.X = SubChunkCoord(x)
+					loc.Y = SubChunkCoord(y)
+					loc.Z = SubChunkCoord(z)
+					index, ok := loc.BlockIndex()
+					if !ok {
+						// TODO: Can't place a block outside chunk boundaries
+						log.Printf("Couldn't place a leaf block (%v,%v,%v)", loc.X, loc.Y, loc.Z)
+					} else {
+						instance.Chunk.SetBlockByIndex(index, BlockId(18), byte(0))
+					}
+				}
+			}
+		}
+	}
+
 	return true
 }

--- a/src/chunkymonkey/generation/chunkgen.go
+++ b/src/chunkymonkey/generation/chunkgen.go
@@ -260,10 +260,9 @@ func (gen *TestGenerator) addSaplings(data *ChunkData) {
 	}
 }
 
-// adjacentBlockIs returns whether or not the blocks that are adjacent to
-// the block at (bx,by,bz) are of type 'blockType'. The area which this
-// function checks is specified by dx, dy, dz. So to check 1 block in all
-// directions, you can specify 1,1,1.
+// adjacentBlockIs return whether or not at least one block adjacent to
+// (bx,by,bz) is of type 'blockType'. The area which this function checks is
+// specified by dx,dy,dz. Blocks outside the given chunk are not checked.
 func adjacentBlockIs(data *ChunkData, bx, by, bz, dx, dy, dz int, blockType byte) bool {
 	subChunk := new(SubChunkXyz)
 

--- a/src/chunkymonkey/generation/chunkgen.go
+++ b/src/chunkymonkey/generation/chunkgen.go
@@ -70,12 +70,19 @@ func (data *ChunkData) RootTag() nbt.ITag {
 // TestGenerator implements chunkstore.IChunkStore.
 type TestGenerator struct {
 	heightSource ISource
+	randSource   rand.Source
+	randGen      *rand.Rand
 }
 
 func NewTestGenerator(seed int64) *TestGenerator {
 	perlin := perlin.NewPerlinNoise(seed)
 
+	randSource := rand.NewSource(time.Nanoseconds())
+	randGen := rand.New(randSource)
+
 	return &TestGenerator{
+		randSource: randSource,
+		randGen:    randGen,
 		heightSource: &Sum{
 			Inputs: []ISource{
 				&Turbulence{
@@ -225,8 +232,6 @@ func (gen *TestGenerator) setSkylight(data *ChunkData) {
 
 }
 
-var treeChance = rand.New(rand.NewSource(time.Nanoseconds()))
-
 func (gen *TestGenerator) addSaplings(data *ChunkData) {
 	baseIndex := 0
 	heightMapIndex := 0
@@ -240,7 +245,7 @@ func (gen *TestGenerator) addSaplings(data *ChunkData) {
 
 			if data.blocks[blockIndex] == 2 {
 				// We could add a tree, check to see if we want to
-				addTree := treeChance.Intn(100) > 95
+				addTree := gen.randGen.Intn(100) > 95
 				if addTree && x > 0 && x < ChunkSizeH-1 && z > 0 && z < ChunkSizeH-1 {
 					if !adjacentBlockIs(data, x, topBlock, z, 2, 2, 2, 6) {
 						// Check if an adjacent block has a sapling already


### PR DESCRIPTION
Currently the saplings do not grow, although a skeleton aspect has been created for this purpose. A top-level grass block has a 5% chance of spawning a sapling, and saplings will not spawn within 2 blocks of another sapling in any direction.
